### PR TITLE
Refactor of timer handling. Properly handle batches of different sizes.

### DIFF
--- a/include/wiretime.h
+++ b/include/wiretime.h
@@ -56,6 +56,7 @@ extern bool debugen;// = false;
 extern bool running;// = true;
 
 struct pkt_time {
+	bool invalid;
 	__u16 seq;
 	struct timespec xmit;
 	struct timespec recv;
@@ -64,20 +65,26 @@ struct pkt_time {
 typedef struct packets {
 	pthread_mutex_t list_lock;
 	struct pkt_time *list;
+	int list_start;
 	int list_head;
 	int list_len;
 	__u16 next_seq;
 	bool txcount_flag;
 	unsigned char *frame;
 	size_t frame_size;
+	int timerfd;
+	int triggers_behind_timer;
 } Packets;
 
 typedef struct config {
-	int pkts_per_sec; /* Max 1000 (1 pkts per ms) */
-	int pkts_per_summary; /* Defaults to pkt_per_sec if not set*/
+	//int pkts_per_sec; /* Max 1000 (1 pkt per ms) */
+	int interval; /* Milliseconds. */
+	//int pkts_per_summary; /* Defaults to pkt_per_sec if not set*/
+	int batch_size; /* Default: 1 */
 	int pcp;
 	int priority;
 	int vlan;
+	bool software_ts;
 	bool one_step;
 	bool ptp_only;
 	bool has_first;
@@ -100,8 +107,8 @@ struct thread_data {
 void get_timestamp(struct msghdr *msg, struct timespec **stamp, int recvmsg_flags, Packets *pkts);
 void *rcv_pkt(void *arg);
 void rcv_xmit_tstamp(int sock, Config *cfg, Packets *pkts, __u16 tx_seq);
-int setup_tx_sock(char *iface, int prio, bool ptp_only, bool one_step);
-int setup_rx_sock(char *iface, int prio, bool ptp_only);
+int setup_tx_sock(char *iface, int prio, bool ptp_only, bool one_step, bool software_ts);
+int setup_rx_sock(char *iface, int prio, bool ptp_only, bool software_ts);
 
 /* wiretime.c */
 void save_tstamp(struct timespec *stamp, unsigned char *data, size_t length,

--- a/include/wiretime.h
+++ b/include/wiretime.h
@@ -104,7 +104,7 @@ struct thread_data {
 };
 
 /* timestamping.c */
-void get_timestamp(struct msghdr *msg, struct timespec **stamp, int recvmsg_flags, Packets *pkts);
+void get_timestamp(struct msghdr *msg, struct timespec **stamp, int recvmsg_flags, Packets *pkts, Config *cfg);
 void *rcv_pkt(void *arg);
 void rcv_xmit_tstamp(int sock, Config *cfg, Packets *pkts, __u16 tx_seq);
 int setup_tx_sock(char *iface, int prio, bool ptp_only, bool one_step, bool software_ts);

--- a/include/wiretime.h
+++ b/include/wiretime.h
@@ -65,7 +65,6 @@ typedef struct packets {
 	unsigned char *frame;
 	size_t frame_size;
 	int timerfd;
-	int triggers_behind_timer;
 } Packets;
 
 typedef struct config {
@@ -83,6 +82,7 @@ typedef struct config {
 	bool plot;
 	char *plot_filename;
 	struct timespec first_tstamp;
+	int triggers_behind_timer;
 	FILE *out_file;
 	char *out_filename;
 	char *tx_iface;

--- a/include/wiretime.h
+++ b/include/wiretime.h
@@ -45,13 +45,6 @@
 
 #define DEBUG(...) _DEBUG(stderr, __VA_ARGS__)
 
-static void bail(const char *error)
-{
-	printf("%s: %s\n", error, strerror(errno));
-	exit(1);
-}
-
-
 extern bool debugen;// = false;
 extern bool running;// = true;
 
@@ -100,6 +93,7 @@ struct thread_data {
 	Config *cfg;
 	Packets *pkts;
 	int sockfd;
+	int tx_sockfd;
 };
 
 /* timestamping.c */

--- a/include/wiretime.h
+++ b/include/wiretime.h
@@ -56,7 +56,6 @@ extern bool debugen;// = false;
 extern bool running;// = true;
 
 struct pkt_time {
-	bool invalid;
 	__u16 seq;
 	struct timespec xmit;
 	struct timespec recv;
@@ -104,6 +103,7 @@ struct thread_data {
 };
 
 /* timestamping.c */
+void print_timestamp(const char *str, struct timespec stamp);
 void get_timestamp(struct msghdr *msg, struct timespec **stamp, int recvmsg_flags, Packets *pkts, Config *cfg);
 void *rcv_pkt(void *arg);
 void rcv_xmit_tstamp(int sock, Config *cfg, Packets *pkts, __u16 tx_seq);

--- a/src/liblink.c
+++ b/src/liblink.c
@@ -38,6 +38,11 @@ int get_smac(int sockfd, char ifname[IFNAMSIZ], unsigned char smac[6])
 	memcpy(buffer.ifr_ifrn.ifrn_name, ifname, IFNAMSIZ);
 
 	if (ioctl(sockfd, SIOCGIFHWADDR, &buffer) < 0) {
+		/* FIXME: Virtual hardware interfaces cannot use SIOCGIFHWADDR.
+		 * Maybe use the `ip link` interface?
+		 */
+		memcpy(smac, "\xAA\xAA\xAA\xAA\xAA\xAA", ETH_ALEN);
+		return 0;
 		printf("smac %2X\n", buffer.ifr_hwaddr.sa_data[0]);
 		perror("Error");
 		ERR("Unable to find source MAC\n");

--- a/src/liblink.c
+++ b/src/liblink.c
@@ -5,6 +5,7 @@
 
 #include <net/if.h>
 #include <netinet/ip.h>
+#include <unistd.h>
 /*#include <stdlib.h>*/
 #include <stdio.h>
 #include <string.h>

--- a/src/timestamping.c
+++ b/src/timestamping.c
@@ -18,6 +18,11 @@
 
 #include "wiretime.h"
 
+void print_timestamp(const char *str, struct timespec stamp)
+{
+	printf("Timestamp %s: %ld.%ld\n", str, stamp.tv_sec, stamp.tv_nsec);
+}
+
 
 void get_timestamp(struct msghdr *msg, struct timespec **stamp, int recvmsg_flags, Packets *pkts, Config *cfg)
 {
@@ -87,7 +92,6 @@ static void recvpacket(int sock, int recvmsg_flags,
 	res = recvmsg(sock, &msg, recvmsg_flags | MSG_DONTWAIT);
 	if (res >= 0) {
 		get_timestamp(&msg, &stamp, recvmsg_flags, pkts, cfg);
-		printf("Time %ld.%ld\n", stamp->tv_sec, stamp->tv_nsec);
 		if (!stamp)
 			return;
 		save_tstamp(stamp, msg.msg_iov->iov_base,

--- a/src/wiretime.c
+++ b/src/wiretime.c
@@ -456,7 +456,7 @@ void *sender(void *args)
 	/*int delay_us = 1000 * (1000 / cfg->pkts_per_sec);*/
 	int delay_us = cfg->interval * 1000;
 
-	while (running) {
+	/*while (running) {*/
 		 /*write one packet */
 		tx_seq = sendpacket(sock, length, cfg, pkts);
 		pkts->txcount_flag = 0;
@@ -468,7 +468,7 @@ void *sender(void *args)
 		 /* Receive xmit timestamp for packet */
 		if (!cfg->one_step)
 			rcv_xmit_tstamp(sock, cfg, pkts, tx_seq);
-		usleep(delay_us);
+		/*usleep(delay_us);*/
 
 		/* The first condition checks that it has transmitted more than
 		 * one interval, so we don't check the average right after
@@ -478,7 +478,7 @@ void *sender(void *args)
 		/*if (pkts->next_seq > (__u16)cfg->pkts_per_summary*/
 		    /*&& (pkts->next_seq % cfg->pkts_per_summary) == 0)*/
 			/*calculate_latency(cfg, pkts);*/
-	}
+	/*}*/
 }
 
 void plot(Config *cfg, char *data_filename)
@@ -754,23 +754,23 @@ int main(int argc, char **argv)
 
 	printf("Triggers behind: %d\n", pkts.triggers_behind_timer);
 
-//	pkts.list_len = 65536;
-//	pkts.list = calloc(sizeof(struct pkt_time), pkts.list_len);
-//	if (!pkts.list)
-//		return ENOMEM;
-//
-//	/* Receiver */
-//	rx_args.sockfd = setup_rx_sock(cfg.rx_iface, cfg.priority, cfg.ptp_only, cfg.software_ts);
-//	rx_args.cfg = &cfg;
-//	rx_args.pkts = &pkts;
-//	pthread_create(&rx_thread, NULL, rcv_pkt, &rx_args);
-//
-//	/* Sender */
-//	tx_args.sockfd = setup_tx_sock(cfg.tx_iface, cfg.priority, cfg.ptp_only, cfg.one_step, cfg.software_ts);
-//	get_smac(tx_sock, cfg.tx_iface, mac);
-//	set_smac(pkts.frame, mac);
-//	tx_args.cfg = &cfg;
-//	tx_args.pkts = &pkts;
+	pkts.list_len = 65536;
+	pkts.list = calloc(sizeof(struct pkt_time), pkts.list_len);
+	if (!pkts.list)
+		return ENOMEM;
+
+	/* Receiver */
+	rx_args.sockfd = setup_rx_sock(cfg.rx_iface, cfg.priority, cfg.ptp_only, cfg.software_ts);
+	rx_args.cfg = &cfg;
+	rx_args.pkts = &pkts;
+	pthread_create(&rx_thread, NULL, rcv_pkt, &rx_args);
+
+	/* Sender */
+	tx_args.sockfd = setup_tx_sock(cfg.tx_iface, cfg.priority, cfg.ptp_only, cfg.one_step, cfg.software_ts);
+	get_smac(tx_sock, cfg.tx_iface, mac);
+	set_smac(pkts.frame, mac);
+	tx_args.cfg = &cfg;
+	tx_args.pkts = &pkts;
 	/*pthread_create(&tx_thread, NULL, sender, &tx_args);*/
 
 	/* Main loop */
@@ -818,7 +818,7 @@ int main(int argc, char **argv)
 			read(pkts.timerfd, dummybuf, 8);
 
 		/*pkts.next_seq++;*/
-		/*sender(&tx_args);*/
+		sender(&tx_args);
 		triggers++;
 		current_batch++;
 


### PR DESCRIPTION
- Use fd timers for more accurate transmission intervals.
- Fix handling of batch sizes where the size/interval is really small. Should now handle all cases without issues.
- Adds software timestamping support. Also opens up for the possbility of adding tests.